### PR TITLE
feat: add basic board component

### DIFF
--- a/smallworld-client/src/App.css
+++ b/smallworld-client/src/App.css
@@ -5,38 +5,6 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+h1 {
+  margin-bottom: 1rem;
 }

--- a/smallworld-client/src/App.tsx
+++ b/smallworld-client/src/App.tsx
@@ -1,35 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import Board from './components/Board';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="App">
+      <h1>Small World Prototype</h1>
+      <Board />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/smallworld-client/src/components/Board.css
+++ b/smallworld-client/src/components/Board.css
@@ -1,0 +1,15 @@
+.board {
+  display: inline-grid;
+  grid-template-columns: repeat(5, 60px);
+  grid-template-rows: repeat(5, 60px);
+  gap: 2px;
+}
+
+.cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #f0e68c;
+  border: 1px solid #333;
+  font-size: 0.8rem;
+}

--- a/smallworld-client/src/components/Board.tsx
+++ b/smallworld-client/src/components/Board.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Cell from './Cell';
+import './Board.css';
+
+const BOARD_SIZE = 5; // temporary board size
+
+const Board: React.FC = () => {
+  const rows = Array.from({ length: BOARD_SIZE }, (_, row) => (
+    <div className="board-row" key={row}>
+      {Array.from({ length: BOARD_SIZE }, (_, col) => (
+        <Cell key={col} row={row} col={col} />
+      ))}
+    </div>
+  ));
+
+  return <div className="board">{rows}</div>;
+};
+
+export default Board;

--- a/smallworld-client/src/components/Cell.tsx
+++ b/smallworld-client/src/components/Cell.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './Board.css';
+
+interface CellProps {
+  row: number;
+  col: number;
+}
+
+const Cell: React.FC<CellProps> = ({ row, col }) => {
+  return <div className="cell">{row},{col}</div>;
+};
+
+export default Cell;


### PR DESCRIPTION
## Summary
- scaffold initial board and cell components for a Small World prototype
- simplify App to render the board
- add basic board and cell styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d6c87c04832eab5ac10b8be56761