### PR TITLE
Add terrain types to board cells

### DIFF
--- a/smallworld-client/src/App.css
+++ b/smallworld-client/src/App.css
@@ -5,38 +5,6 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+h1 {
+  margin-bottom: 1rem;
 }

--- a/smallworld-client/src/App.tsx
+++ b/smallworld-client/src/App.tsx
@@ -1,35 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import Board from './components/Board';
+import './App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="App">
+      <h1>Small World Prototype</h1>
+      <Board />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/smallworld-client/src/components/Board.css
+++ b/smallworld-client/src/components/Board.css
@@ -1,0 +1,38 @@
+.board {
+  display: inline-grid;
+  grid-template-columns: repeat(5, 60px);
+  grid-template-rows: repeat(5, 60px);
+  gap: 2px;
+}
+
+.board-row {
+  display: contents;
+}
+
+.cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 1px solid #333;
+  font-size: 0.8rem;
+}
+
+.cell.forest {
+  background-color: #228b22;
+}
+
+.cell.hill {
+  background-color: #cd853f;
+}
+
+.cell.mountain {
+  background-color: #a9a9a9;
+}
+
+.cell.water {
+  background-color: #1e90ff;
+}
+
+.cell.plains {
+  background-color: #f0e68c;
+}

--- a/smallworld-client/src/components/Board.tsx
+++ b/smallworld-client/src/components/Board.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Cell from './Cell';
+import './Board.css';
+import { TERRAINS } from '../types/terrain';
+import type { Terrain } from '../types/terrain';
+
+const BOARD_SIZE = 5; // temporary board size
+
+const generateBoard = (): Terrain[][] =>
+  Array.from({ length: BOARD_SIZE }, () =>
+    Array.from({ length: BOARD_SIZE }, () =>
+      TERRAINS[Math.floor(Math.random() * TERRAINS.length)]
+    )
+  );
+
+const Board: React.FC = () => {
+  const board = React.useMemo<Terrain[][]>(generateBoard, []);
+
+  return (
+    <div className="board">
+      {board.map((rowData, row) => (
+        <div className="board-row" key={row}>
+          {rowData.map((terrain, col) => (
+            <Cell key={col} terrain={terrain} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Board;

--- a/smallworld-client/src/components/Cell.tsx
+++ b/smallworld-client/src/components/Cell.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './Board.css';
+import type { Terrain } from '../types/terrain';
+
+interface CellProps {
+  terrain: Terrain;
+}
+
+const Cell: React.FC<CellProps> = ({ terrain }) => {
+  return <div className={`cell ${terrain}`}>{terrain[0].toUpperCase()}</div>;
+};
+
+export default Cell;

--- a/smallworld-client/src/types/terrain.ts
+++ b/smallworld-client/src/types/terrain.ts
@@ -1,0 +1,3 @@
+export type Terrain = 'forest' | 'hill' | 'mountain' | 'water' | 'plains';
+
+export const TERRAINS: Terrain[] = ['forest', 'hill', 'mountain', 'water', 'plains'];


### PR DESCRIPTION
## Summary
- randomize board layout with predefined terrain types
- color-code cells for forest, hill, mountain, water, and plains

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6d6c87c04832eab5ac10b8be56761