### PR TITLE
Add hexagonal board layout

### DIFF
--- a/smallworld-client/src/components/Board.css
+++ b/smallworld-client/src/components/Board.css
@@ -12,16 +12,20 @@
   display: flex;
 }
 
+.board-row:nth-child(even) {
+  margin-left: 30px;
+}
+
 .cell {
-  width: 50px;
-  height: 50px;
+  width: 60px;
+  height: 52px;
   display: flex;
   justify-content: center;
   align-items: center;
   border: 1px solid #333;
   font-size: 0.8rem;
   cursor: pointer;
-  clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
 }
 
 .cell.border {

--- a/smallworld-client/src/components/Board.tsx
+++ b/smallworld-client/src/components/Board.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useState } from "react";
 import Cell from "./Cell";
 import type { Cell as CellType } from "../types/cell";
-import { createBoard } from "../utils/mapgenerator";
+import { createHexBoard } from "../utils/hexBoard";
 import "./Board.css";
 
 const Board: React.FC = () => {
   const [board, setBoard] = useState<CellType[][]>([]);
 
   useEffect(() => {
-    const { board } = createBoard();
+    const { board } = createHexBoard();
     setBoard(board);
   }, []);
 

--- a/smallworld-client/src/utils/hexBoard.ts
+++ b/smallworld-client/src/utils/hexBoard.ts
@@ -1,0 +1,30 @@
+import type { Cell } from "../types/cell";
+import type { Region } from "../types/region";
+import type { Terrain } from "../types/terrain";
+
+const HEX_ROWS: Terrain[][] = [
+  ["forest", "hill", "mountain"],
+  ["plains", "forest", "hill", "mountain"],
+  ["forest", "hill", "mountain", "plains", "forest"],
+  ["hill", "mountain", "plains", "forest"],
+  ["mountain", "plains", "forest"],
+];
+
+export const createHexBoard = (): { board: Cell[][]; regions: Region[] } => {
+  const board: Cell[][] = [];
+  const regions: Region[] = [];
+  let id = 0;
+
+  HEX_ROWS.forEach((row, rIdx) => {
+    const rowCells: Cell[] = [];
+    row.forEach((terrain, cIdx) => {
+      id += 1;
+      rowCells.push({ id, terrain, regionId: id, border: false });
+      regions.push({ id, terrain, cells: [[rIdx, cIdx]] });
+    });
+    board.push(rowCells);
+  });
+
+  return { board, regions };
+};
+


### PR DESCRIPTION
## Summary
- create fixed hexagonal board layout with 3-4-5-4-3 rows
- render board using new hex map
- style cells as hexagons and offset alternate rows for hex grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0e22c76bc832e82de9f41670cb404